### PR TITLE
F24-01: 過剰熱量ロジックの改良

### DIFF
--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -33,10 +33,13 @@ def calc_carryover(
     # 季節の判断
     if H and C:
         raise ValueError("想定外の季節")
+    # 暖冷房ともに有効であれば正となるように算出
     elif H:
-        temperature_diff = Theta_HBR_i - Theta_star_HBR
+        # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
+        temperature_diff = np.clip(Theta_HBR_i - Theta_star_HBR, 0, None)
     elif C:
-        temperature_diff = Theta_star_HBR - Theta_HBR_i
+        # 過剰熱量がない部屋は負の過剰熱量にならないようクリップする
+        temperature_diff = np.clip(Theta_star_HBR - Theta_HBR_i, 0, None)
     else:
         # 空調なし -> 過剰熱量なし
         return np.zeros((5, 1))
@@ -182,15 +185,15 @@ def get_Theta_HBR_i_2023(
         Theta_HBR_i = Theta_star_HBR \
                     + (ac_capacity + carryover_capacity - load_capacity) \
                     / (c_ac_air + c_prt + heat_loss + cbri)
-        # 負荷バランス時の居室の室温で下限を設定
-        Theta_HBR_i = np.clip(Theta_HBR_i, Theta_star_HBR, None)
+        # NOTE: 負荷バランス時の居室の室温で下限を設定 -> しない
+        # Theta_HBR_i = np.clip(Theta_HBR_i, Theta_star_HBR, None)
     elif C:  # 冷房期 (46-2)
         load_capacity = L_star_CS_i * 10**6  # [MJ/h] -> [J/h]
         Theta_HBR_i = Theta_star_HBR \
                     -1 * (ac_capacity + carryover_capacity - load_capacity) \
                     / (c_ac_air + c_prt + heat_loss + cbri)
-        # 負荷バランス時の居室の室温で上限を設定
-        Theta_HBR_i = np.clip(Theta_HBR_i, None, Theta_star_HBR)
+        # NOTE: 負荷バランス時の居室の室温で下限を設定 -> しない
+        # Theta_HBR_i = np.clip(Theta_HBR_i, None, Theta_star_HBR)
     elif M:  # 中間期 (46-3)
         Theta_HBR_i = Theta_star_HBR * np.ones((5, 1))
 

--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -51,7 +51,6 @@ def calc_carryover(
 # MATRIX[:, t] -> Shape(5, )
 # MATRIX[:, t:t+1] -> Shape(5, 1)
 
-@log_res(['L_star_H_i'])
 def get_L_star_H_i_2024(
         H: bool,
         L_H_i: NDArray[Shape["5, 1"], Float64],
@@ -82,7 +81,6 @@ def get_L_star_H_i_2024(
     assert np.all(0 <= L_star_H_i), "負荷バランス時の暖房負荷は負にならない"
     return L_star_H_i
 
-@log_res(['L_star_CS_i'])
 def get_L_star_CS_i_2024(
         C: bool,
         L_CS_i: NDArray[Shape["5, 1"], Float64],

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -440,80 +440,60 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
             if type == PROCESS_TYPE_1 or type == PROCESS_TYPE_3:
                 # (33)
                 L_star_CL_d_t = dc.get_L_star_CL_d_t(L_star_CL_d_t_i)
-
                 # (32)
                 L_star_CS_d_t = dc.get_L_star_CS_d_t(L_star_CS_d_t_i)
-
                 # (31)
                 L_star_CL_max_d_t = dc.get_L_star_CL_max_d_t(L_star_CS_d_t)
-
                 # (30)
                 L_star_dash_CL_d_t = dc.get_L_star_dash_CL_d_t(L_star_CL_max_d_t, L_star_CL_d_t)
-
                 # (29)
                 L_star_dash_C_d_t = dc.get_L_star_dash_C_d_t(L_star_CS_d_t, L_star_dash_CL_d_t)
-
                 # (28)
                 SHF_dash_d_t = dc.get_SHF_dash_d_t(L_star_CS_d_t, L_star_dash_C_d_t)
-
                 # (27)
                 Q_hs_max_C_d_t = dc.get_Q_hs_max_C_d_t_2024(type, q_hs_rtd_C, input_C_af_C)
-
                 # (26)
                 Q_hs_max_CL_d_t = dc.get_Q_hs_max_CL_d_t(Q_hs_max_C_d_t, SHF_dash_d_t, L_star_dash_CL_d_t)
-
                 # (25)
                 Q_hs_max_CS_d_t = dc.get_Q_hs_max_CS_d_t(Q_hs_max_C_d_t, SHF_dash_d_t)
-
                 # (24)
                 C_df_H_d_t = dc.get_C_df_H_d_t(Theta_ex_d_t, h_ex_d_t)
-
                 # (23)
                 Q_hs_max_H_d_t = dc.get_Q_hs_max_H_d_t_2024(type, q_hs_rtd_H, C_df_H_d_t, input_C_af_H)
 
             elif type == PROCESS_TYPE_2 or type == PROCESS_TYPE_4:
                 # (24)　デフロストに関する暖房出力補正係数
                 C_df_H_d_t = dc.get_C_df_H_d_t(Theta_ex_d_t, h_ex_d_t)
-
                 # 最大暖房能力比
                 q_r_max_H = rac.get_q_r_max_H(q_max_H, q_rtd_H)
-
                 # 最大暖房出力比
                 Q_r_max_H_d_t = rac.calc_Q_r_max_H_d_t(q_rtd_C, q_r_max_H, Theta_ex_d_t)
-
                 # 最大暖房出力
                 Q_max_H_d_t = rac.calc_Q_max_H_d_t(Q_r_max_H_d_t, q_rtd_H, Theta_ex_d_t, h_ex_d_t, input_C_af_H)
                 Q_hs_max_H_d_t = Q_max_H_d_t
-
                 # 最大冷房能力比
                 q_r_max_C = rac.get_q_r_max_C(q_max_C, q_rtd_C)
-
                 # 最大冷房出力比
                 Q_r_max_C_d_t = rac.calc_Q_r_max_C_d_t(q_r_max_C, q_rtd_C, Theta_ex_d_t)
-
                 # 最大冷房出力
                 Q_max_C_d_t = rac.calc_Q_max_C_d_t(Q_r_max_C_d_t, q_rtd_C, input_C_af_C)
                 Q_hs_max_C_d_t = Q_max_C_d_t
-
                 # 冷房負荷最小顕熱比
                 SHF_L_min_c = rac.get_SHF_L_min_c()
-
                 # 最大冷房潜熱負荷
                 L_max_CL_d_t = rac.get_L_max_CL_d_t(np.sum(L_CS_d_t_i, axis=0), SHF_L_min_c)
-
                 # 補正冷房潜熱負荷
                 L_dash_CL_d_t = rac.get_L_dash_CL_d_t(L_max_CL_d_t, np.sum(L_CL_d_t_i, axis=0))
                 L_dash_C_d_t = rac.get_L_dash_C_d_t(np.sum(L_CS_d_t_i, axis=0), L_dash_CL_d_t)
-
                 # 冷房負荷補正顕熱比
                 SHF_dash_d_t = rac.get_SHF_dash_d_t(np.sum(L_CS_d_t_i, axis=0), L_dash_C_d_t)
-
                 # 最大冷房顕熱出力, 最大冷房潜熱出力
                 Q_max_CS_d_t = rac.get_Q_max_CS_d_t(Q_max_C_d_t, SHF_dash_d_t)
                 Q_max_CL_d_t = rac.get_Q_max_CL_d_t(Q_max_C_d_t, SHF_dash_d_t, L_dash_CL_d_t)
                 Q_hs_max_C_d_t = Q_max_C_d_t
                 Q_hs_max_CL_d_t = Q_max_CL_d_t
                 Q_hs_max_CS_d_t = Q_max_CS_d_t
+
             else:
                 raise Exception('設備機器の種類の入力が不正です。')
             ####################################################################################################################

--- a/src/jjjexperiment/section4_2_a.py
+++ b/src/jjjexperiment/section4_2_a.py
@@ -8,13 +8,14 @@ import pyhees.section4_3
 
 # JJJ
 from jjjexperiment.denchu_1 import Spec
-from jjjexperiment.logger import LimitedLoggerAdapter as _logger  # デバッグ用ロガー
+from jjjexperiment.logger import LimitedLoggerAdapter as _logger, log_res  # デバッグ用ロガー
 import jjjexperiment.constants as constants
 from jjjexperiment.constants import PROCESS_TYPE_1, PROCESS_TYPE_2, PROCESS_TYPE_3, PROCESS_TYPE_4
 import jjjexperiment.denchu_2 as denchu_2
 from jjjexperiment.options import *
 import jjjexperiment.ac_min_volume_input as jjj_V_min_input
 
+@log_res(['E_E_fan_H_d_t', 'q_hs_H_d_t'])
 def calc_E_E_fan_H_d_t(
         type, region, case_name,
         Theta_hs_out_d_t, Theta_hs_in_d_t,  # 空気温度
@@ -48,9 +49,9 @@ def calc_E_E_fan_H_d_t(
     else:
         raise ValueError(constants.input_V_hs_min)
 
-    _logger.NDdebug("E_E_fan_H_d_t", E_E_fan_H_d_t)
     return E_E_fan_H_d_t, q_hs_H_d_t
 
+@log_res(['E_E_fan_C_d_t', 'q_hs_CS_d_t', 'q_hs_CL_d_t'])
 def calc_E_E_fan_C_d_t(
         type, region, case_name,
         Theta_hs_out_d_t, Theta_hs_in_d_t,
@@ -90,9 +91,9 @@ def calc_E_E_fan_C_d_t(
     else:
         raise ValueError(constants.input_V_hs_min)
 
-    _logger.NDdebug("E_E_fan_C_d_t", E_E_fan_C_d_t)
     return E_E_fan_C_d_t, q_hs_CS_d_t, q_hs_CL_d_t
 
+@log_res(['E_E_H_d_t(type:1,3)'])
 def calc_E_E_H_d_t_type1_and_type3(
         type: str,
         E_E_fan_H_d_t: NDArray[Shape['8760'], Float64],
@@ -140,6 +141,7 @@ def calc_E_E_H_d_t_type1_and_type3(
     E_E_H_d_t = E_E_comp_H_d_t + E_E_fan_H_d_t  # (1)
     return E_E_H_d_t
 
+@log_res(['E_E_H_d_t(type:2)'])
 def calc_E_E_H_d_t_type2(
         type: str,
         region: int,
@@ -170,6 +172,7 @@ def calc_E_E_H_d_t_type2(
     E_E_H_d_t = E_E_fan_H_d_t + E_E_CRAC_H_d_t
     return E_E_H_d_t
 
+@log_res(['E_E_H_d_t(type:4)'])
 def calc_E_E_H_d_t_type4(
         case_name: str,
         type: str,
@@ -224,6 +227,7 @@ def calc_E_E_H_d_t_type4(
     E_E_H_d_t = E_E_fan_H_d_t + E_E_CRAC_H_d_t
     return E_E_H_d_t
 
+@log_res(['E_E_C_d_t(type:1,3)'])
 def calc_E_E_C_d_t_type1_and_type3(
         type, region,
         E_E_fan_C_d_t: NDArray[Shape['8760'], Float64],
@@ -276,6 +280,7 @@ def calc_E_E_C_d_t_type1_and_type3(
     E_E_C_d_t = E_E_comp_C_d_t + E_E_fan_C_d_t  # (2)
     return E_E_C_d_t
 
+@log_res(['E_E_C_d_t(type:2)'])
 def calc_E_E_C_d_t_type2(
         type: str,
         region: int,
@@ -305,6 +310,7 @@ def calc_E_E_C_d_t_type2(
     E_E_C_d_t = E_E_CRAC_C_d_t + E_E_fan_C_d_t  # (2)
     return E_E_C_d_t
 
+@log_res(['E_E_C_d_t(type:4)'])
 def calc_E_E_C_d_t_type4(
         case_name: str,
         type: str,

--- a/src/pyhees/section4_2.py
+++ b/src/pyhees/section4_2.py
@@ -998,7 +998,8 @@ def get_X_hs_in_d_t(X_NR_d_t):
 # 9.2 熱源機の出口における空気温度・絶対湿度
 # ============================================================================
 
-@log_res(['Theta_hs_out_d_t'])
+# 過剰熱量ループ内で使用
+# @log_res(['Theta_hs_out_d_t'])
 def get_Theta_hs_out_d_t(VAV, Theta_req_d_t_i, V_dash_supply_d_t_i, L_star_H_d_t_i, L_star_CS_d_t_i, region, Theta_NR_d_t,
                          Theta_hs_out_max_H_d_t, Theta_hs_out_min_C_d_t):
     """(14-1)(14-2)(14-3)(14-4)(14-5)(14-6)
@@ -1198,7 +1199,8 @@ def get_X_star_hs_in_d_t(X_star_NR_d_t):
 # ============================================================================
 
 @constants.jjjexperiment_mod
-@log_res(['Theta_req_d_t_i'])
+# 過剰熱量ループ内で使用
+# @log_res(['Theta_req_d_t_i'])
 def get_Theta_req_d_t_i(Theta_sur_d_t_i, Theta_star_HBR_d_t, V_dash_supply_d_t_i, L_star_H_d_t_i, L_star_CS_d_t_i,
                         l_duct_i, region):
     """(21-1)(21-2)(21-3)
@@ -1831,7 +1833,8 @@ def calc_Q_hat_hs_d_t(Q, A_A, V_vent_l_d_t, V_vent_g_i, mu_H, mu_C, J_d_t, q_gen
 # 10.1 吹き出し空気温度
 # ============================================================================
 
-@log_res(['Theta_supply_d_t_i'])
+# 過剰熱量ループ内で使用
+# @log_res(['Theta_supply_d_t_i'])
 def get_Thata_supply_d_t_i(Theta_sur_d_t_i, Theta_hs_out_d_t, Theta_star_HBR_d_t, l_duct_i,
                                                    V_supply_d_t_i, L_star_H_d_t_i, L_star_CS_d_t_i, region):
     """(41-1)(41-2)(41-3)
@@ -1923,7 +1926,8 @@ def get_X_supply_d_t_i(X_star_HBR_d_t, X_hs_out_d_t, L_star_CL_d_t_i, region):
 # 10.3 吹き出し風量
 # ============================================================================
 
-@log_res(['V_supply_d_t_i'])
+# 過剰熱量ループ内で使用
+# @log_res(['V_supply_d_t_i'])
 def cap_V_supply_d_t_i(V_supply_d_t_i, V_dash_supply_d_t_i, V_vent_g_i, region, V_hs_dsgn_H, V_hs_dsgn_C):
 
     V_vent_g_i = np.reshape(V_vent_g_i, (5, 1))

--- a/src/pyhees/section4_2_a.py
+++ b/src/pyhees/section4_2_a.py
@@ -409,6 +409,7 @@ def get_e_r_H_d_t_2023(q_hs_H_d_t):
 
     return e_r_H_d_t
 
+@log_res(['e_r_H_d_t'])
 def get_e_r_H_d_t(q_hs_H_d_t, q_hs_rtd_H, q_hs_min_H, q_hs_mid_H, e_r_mid_H, e_r_min_H, e_r_rtd_H):
     """(9-1)(9-2)(9-3)(9-4)
 

--- a/src/pyhees/section4_2_a.py
+++ b/src/pyhees/section4_2_a.py
@@ -331,7 +331,9 @@ def get_E_E_comp_H_d_t(q_hs_H_d_t, e_hs_H_d_t):
     """
     E_E_comp_H_d_t = np.zeros(24 * 365)
 
-    f = q_hs_H_d_t > 0
+    # NOTE(F24-01): np.clip(Theta_HBR_i, Theta_star_HBR, None)
+    # キャップをやめたことによる 0除算の対策
+    f = np.logical_and(q_hs_H_d_t > 0, e_hs_H_d_t > 0)
 
     E_E_comp_H_d_t[f] = (q_hs_H_d_t[f] / e_hs_H_d_t[f]) * 10 ** (-3)
 

--- a/src/tests/carryover_heat/test_4_2_formula_46_48.py
+++ b/src/tests/carryover_heat/test_4_2_formula_46_48.py
@@ -45,8 +45,7 @@ def test_過剰熱量繰越を考慮した室温_居室_式46():
     assert Theta_HBR_i.shape == (5, 1), "Theta_HBR_iの次数が想定外"
 
     # NOTE: 資料ではキャップされていないが、実装ではキャップされている
-    # 参考: np.array([19.63, 21.29, 21.48, 19.96, 19.59]).reshape(-1,1)
-    exp_Theta_HBR_i = np.array([20.0, 21.29, 21.49, 20.0, 20.0]).reshape(-1,1)
+    exp_Theta_HBR_i = np.array([19.63, 21.29, 21.49, 19.97, 19.64]).reshape(-1,1)
 
     np.testing.assert_almost_equal(Theta_HBR_i, exp_Theta_HBR_i, decimal=2), "Theta_HBR_iの計算がおかしい"
     # assert つかないの間違えやすいので注意


### PR DESCRIPTION
変更内容はチームズでの先生の提案からです。転記します。
こちらに対応いたしました。
@yusuke-arai 

> 46式の計算時に、暖房時に20℃を下回る場合は20℃にするとあります。20℃に補正した後に48式に代入すると、温度が上昇し続けるのではないかと思います。46式の計算後に20℃を下回った場合は、48式の計算時に20℃を下回った値で計算すると、温度が上昇しなくなるのではないでしょうか？1/1 2:00の温度も17.94℃→17.81℃になりました。ただし、他の場所では20℃にした方が良いと思います。

BEFORE:

![スクリーンショット 2025-02-17 185831](https://github.com/user-attachments/assets/1fb7aad3-5801-4f5c-b69d-a0bac3134e89)

AFTER:

![スクリーンショット 2025-02-17 185930](https://github.com/user-attachments/assets/6e14a236-b4a8-450c-b668-61acfaa10a24)

Theta_NR_d_t が単増加する問題についてはそのままだったので、Theta_NR_d_t のキャップは活かしたままです。
佑介さんとお話して気づきましたが、Theta_NR が Theta_HBR 以上に空調される前提がモデル上はないため、
コードにのみキャップが追加されることは合理的だと個人的には感じています。
