### PR TITLE
google colab numpy2系追従対応

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -53,68 +53,58 @@ files = [
 dev = ["black (==24.3.0)", "build (==1.0.3)", "check-manifest (==0.49)", "click (==8.1.7)", "coverage[toml] (==7.3.2)", "exceptiongroup (==1.2.0)", "importlib-metadata (==7.0.0)", "iniconfig (==2.0.0)", "mypy (==1.7.1)", "mypy-extensions (==1.0.0)", "packaging (==23.2)", "pathspec (==0.12.1)", "platformdirs (==4.1.0)", "pluggy (==1.3.0)", "pyproject-hooks (==1.0.0)", "pytest (==7.4.3)", "pytest-cov (==4.1.0)", "tomli (==2.0.1)", "typing-extensions (==4.9.0)", "zipp (==3.17.0)"]
 
 [[package]]
-name = "nptyping"
-version = "2.0.1"
-description = "Type hints for NumPy."
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "nptyping-2.0.1-py3-none-any.whl", hash = "sha256:0fc5c4d76c65e12a77e750b9e2701dab6468d00926c8c4f383867bd70598a532"},
-]
-
-[package.dependencies]
-numpy = ">=1.20.0"
-
-[package.extras]
-build = ["codecov (>=2.1.0)", "invoke (>=1.6.0)", "pip-tools (>=6.5.0)"]
-dev = ["autoflake", "beartype (<0.10.0)", "beartype (>=0.10.0)", "black", "codecov (>=2.1.0)", "coverage", "invoke (>=1.6.0)", "isort", "mypy", "pip-tools (>=6.5.0)", "pylint", "setuptools", "typeguard", "wheel"]
-qa = ["autoflake", "beartype (<0.10.0)", "beartype (>=0.10.0)", "black", "coverage", "isort", "mypy", "pylint", "setuptools", "typeguard", "wheel"]
-
-[[package]]
 name = "numpy"
-version = "1.26.4"
+version = "2.0.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
-    {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4"},
-    {file = "numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a"},
-    {file = "numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2"},
-    {file = "numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07"},
-    {file = "numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71"},
-    {file = "numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e"},
-    {file = "numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a"},
-    {file = "numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a"},
-    {file = "numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20"},
-    {file = "numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218"},
-    {file = "numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"},
-    {file = "numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a"},
-    {file = "numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0"},
-    {file = "numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110"},
-    {file = "numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c"},
-    {file = "numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764"},
-    {file = "numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd"},
-    {file = "numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c"},
-    {file = "numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6"},
-    {file = "numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c"},
-    {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
-    {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8c5713284ce4e282544c68d1c3b2c7161d38c256d2eefc93c1d683cf47683e66"},
+    {file = "numpy-2.0.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:becfae3ddd30736fe1889a37f1f580e245ba79a5855bff5f2a29cb3ccc22dd7b"},
+    {file = "numpy-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2da5960c3cf0df7eafefd806d4e612c5e19358de82cb3c343631188991566ccd"},
+    {file = "numpy-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:496f71341824ed9f3d2fd36cf3ac57ae2e0165c143b55c3a035ee219413f3318"},
+    {file = "numpy-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a61ec659f68ae254e4d237816e33171497e978140353c0c2038d46e63282d0c8"},
+    {file = "numpy-2.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d731a1c6116ba289c1e9ee714b08a8ff882944d4ad631fd411106a30f083c326"},
+    {file = "numpy-2.0.2-cp310-cp310-win32.whl", hash = "sha256:984d96121c9f9616cd33fbd0618b7f08e0cfc9600a7ee1d6fd9b239186d19d97"},
+    {file = "numpy-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:c7b0be4ef08607dd04da4092faee0b86607f111d5ae68036f16cc787e250a131"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ca4decb342d66018b01932139c0961a8f9ddc7589611158cb3c27cbcf76448"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:807ec44583fd708a21d4a11d94aedf2f4f3c3719035c76a2bbe1fe8e217bdc57"},
+    {file = "numpy-2.0.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8cafab480740e22f8d833acefed5cc87ce276f4ece12fdaa2e8903db2f82897a"},
+    {file = "numpy-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15f476a45e6e5a3a79d8a14e62161d27ad897381fecfa4a09ed5322f2085669"},
+    {file = "numpy-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13e689d772146140a252c3a28501da66dfecd77490b498b168b501835041f951"},
+    {file = "numpy-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ea91dfb7c3d1c56a0e55657c0afb38cf1eeae4544c208dc465c3c9f3a7c09f9"},
+    {file = "numpy-2.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1c9307701fec8f3f7a1e6711f9089c06e6284b3afbbcd259f7791282d660a15"},
+    {file = "numpy-2.0.2-cp311-cp311-win32.whl", hash = "sha256:a392a68bd329eafac5817e5aefeb39038c48b671afd242710b451e76090e81f4"},
+    {file = "numpy-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:286cd40ce2b7d652a6f22efdfc6d1edf879440e53e76a75955bc0c826c7e64dc"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c"},
+    {file = "numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c"},
+    {file = "numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692"},
+    {file = "numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a"},
+    {file = "numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c"},
+    {file = "numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded"},
+    {file = "numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5"},
+    {file = "numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b"},
+    {file = "numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729"},
+    {file = "numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1"},
+    {file = "numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd"},
+    {file = "numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d"},
+    {file = "numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d"},
+    {file = "numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa"},
+    {file = "numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c"},
+    {file = "numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385"},
+    {file = "numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78"},
 ]
 
 [[package]]
@@ -576,4 +566,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "cdb87b46ef349e9e26b7c4fe5b1b4072315abc4518cc84e7e59b17ec56036978"
+content-hash = "009c1f34a874e940113a39f764b08f61ebf37895868f50d5dea7aa133e12875c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -576,4 +576,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.11"
-content-hash = "6af1d5d02fe6dde901bde0611d8e967cf1b8f434d1a020abf1c23489df985392"
+content-hash = "cdb87b46ef349e9e26b7c4fe5b1b4072315abc4518cc84e7e59b17ec56036978"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "~3.11"  # 3.11.x (= google colab ver.)
-numpy = "1.26.4"  # 2.0系には nptyping が2025.3時点で未対応のため
+numpy = "~2.0"  # 2.0.x (= google colab ver.)
 pandas = ">=2.0.1"
 scipy = ">=1.10.1"
 injector = "*"
-nptyping = "*"
 pydantic = "^2.10.6"
 pyyaml = "^6.0.2"
 
@@ -31,6 +30,3 @@ pytest = "*"
 [tool.pytest.ini_options]
 testpaths = ["src/tests"]
 python_files = ["test_*.py"]
-filterwarnings = [
-    "ignore::DeprecationWarning:nptyping",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "~3.11"  # 3.11.x (= google colab ver.)
-numpy = "<2.0"  # 2.0系には nptyping が2025.3時点で未対応のため
+numpy = "1.26.4"  # 2.0系には nptyping が2025.3時点で未対応のため
 pandas = ">=2.0.1"
 scipy = ">=1.10.1"
 injector = "*"

--- a/src/jjjexperiment/ac_min_volume_input/section4_2.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2.py
@@ -1,17 +1,17 @@
 import numpy as np
-from nptyping import NDArray, Float64, Shape
 
 import pyhees.section4_2 as dc
 # JJJ
+from jjjexperiment.common import *
 import jjjexperiment.constants as jjj_consts
 from jjjexperiment.options import *
 
 def get_V_hs_vent_d_t(
         region: int,
-        V_vent_g_i: NDArray[Shape['5'], Float64],
+        V_vent_g_i: Array5,
         general_ventilation: bool,
         input_V_hs_min: bool
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """(35-1)(35-2) 改造版
 
     Args:

--- a/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
+++ b/src/jjjexperiment/ac_min_volume_input/section4_2_a.py
@@ -1,5 +1,5 @@
 import numpy as np
-from nptyping import NDArray, Shape, Float64
+from jjjexperiment.common import *
 
 # ============================================================================
 # A.6 送風機
@@ -7,10 +7,10 @@ from nptyping import NDArray, Shape, Float64
 
 def get_E_E_fan_d_t(
         P_fan_rtd: float,
-        V_hs_vent_d_t: NDArray[Shape['8760'], Float64],
-        V_hs_supply_d_t: NDArray[Shape['8760'], Float64],
+        V_hs_vent_d_t: Array8760,
+        V_hs_supply_d_t: Array8760,
         V_hs_dsgn: float
-        ) -> NDArray[Shape['8760'], Float64]:
+        ) -> Array8760:
     """(37)改 暖冷房送風機消費電力
 
     Args:

--- a/src/jjjexperiment/carryover_heat/get_C.py
+++ b/src/jjjexperiment/carryover_heat/get_C.py
@@ -1,11 +1,12 @@
 import numpy as np
-from nptyping import NDArray, Shape, Float64
+
 # JJJ
+from jjjexperiment.common import *
 import jjjexperiment.constants as jjj_consts
 
 def get_C_BR_i(
-        A_HCZ_i: NDArray[Shape["5, 1"], Float64]
-    )-> NDArray[Shape["5, 1"], Float64]:
+        A_HCZ_i: Array5x1
+    )-> Array5x1:
     """標準住戸との床面積比率で熱容量を求める
 
     Args:

--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -1,18 +1,18 @@
 import numpy as np
-from nptyping import NDArray, Float64, Shape
 
 import pyhees.section4_2 as dc
 # JJJ
+from jjjexperiment.common import *
 import jjjexperiment.carryover_heat as jjj_carryover_heat
 from jjjexperiment.logger import log_res
 
 def calc_carryover(
         H: bool,
         C: bool,
-        A_HCZ_i: NDArray[Shape["5"], Float64],
-        Theta_HBR_i: NDArray[Shape["5, 1"], Float64],
+        A_HCZ_i: Array5,
+        Theta_HBR_i: Array5x1,
         Theta_star_HBR: float,
-    ) -> NDArray[Shape["5, 1"], Float64]:
+    ) -> Array5x1:
     """過剰熱量 [MJ] (一時点)
 
     Args:
@@ -56,10 +56,10 @@ def calc_carryover(
 
 def get_L_star_H_i_2024(
         H: bool,
-        L_H_i: NDArray[Shape["5, 1"], Float64],
-        Q_star_trs_prt_i: NDArray[Shape["5, 1"], Float64],
-        carryover: NDArray[Shape["5, 1"], Float64],
-    )-> NDArray[Shape["5, 1"], Float64]:
+        L_H_i: Array5x1,
+        Q_star_trs_prt_i: Array5x1,
+        carryover: Array5x1,
+    )-> Array5x1:
     """(8-1)(8-2)(8-3) -> 時点版, 過剰熱量を考慮
 
     Args:
@@ -86,10 +86,10 @@ def get_L_star_H_i_2024(
 
 def get_L_star_CS_i_2024(
         C: bool,
-        L_CS_i: NDArray[Shape["5, 1"], Float64],
-        Q_star_trs_prt_i: NDArray[Shape["5, 1"], Float64],
-        carryover: NDArray[Shape["5, 1"], Float64],
-    )-> NDArray[Shape["5, 1"], Float64]:
+        L_CS_i: Array5x1,
+        Q_star_trs_prt_i: Array5x1,
+        carryover: Array5x1,
+    )-> Array5x1:
     """(9-1)(9-2)(9-3) -> 時点版, 過剰熱量を考慮
 
     Args:
@@ -121,16 +121,16 @@ def get_L_star_CS_i_2024(
 def get_Theta_HBR_i_2023(
         isFirst: bool, H: bool, C: bool, M: bool,
         Theta_star_HBR: float,
-        V_supply_i: NDArray[Shape["5, 1"], Float64],
-        Theta_supply_i: NDArray[Shape["5, 1"], Float64],
+        V_supply_i: Array5x1,
+        Theta_supply_i: Array5x1,
         U_prt: float,
-        A_prt_i: NDArray[Shape["5, 1"], Float64],
+        A_prt_i: Array5x1,
         Q: float,
-        A_HCZ_i: NDArray[Shape["5, 1"], Float64],
-        L_star_H_i: NDArray[Shape["5, 1"], Float64],
-        L_star_CS_i: NDArray[Shape["5, 1"], Float64],
-        Theta_HBR_before_i: NDArray[Shape["5, 1"], Float64]
-        ) -> NDArray[Shape["5, 1"], Float64]:
+        A_HCZ_i: Array5x1,
+        L_star_H_i: Array5x1,
+        L_star_CS_i: Array5x1,
+        Theta_HBR_before_i: Array5x1
+        ) -> Array5x1:
     """(46-1)(46-2)(46-3) -> 時点版, 過剰熱量を考慮
 
     Args:
@@ -205,13 +205,13 @@ def get_Theta_NR_2023(
         isFirst: bool, H: bool, C: bool, M: bool,
         Theta_star_NR: float,
         Theta_star_HBR: float,
-        Theta_HBR_i: NDArray[Shape["5, 1"], Float64],
+        Theta_HBR_i: Array5x1,
         A_NR: float,
         V_vent_l_NR: float,
-        V_dash_supply_i: NDArray[Shape["5, 1"], Float64],
-        V_supply_i: NDArray[Shape["5, 1"], Float64],
+        V_dash_supply_i: Array5x1,
+        V_supply_i: Array5x1,
         U_prt: float,
-        A_prt_i: NDArray[Shape["5, 1"], Float64],
+        A_prt_i: Array5x1,
         Q: float,
         Theta_NR_before: float
         ) -> float:

--- a/src/jjjexperiment/common.py
+++ b/src/jjjexperiment/common.py
@@ -1,4 +1,16 @@
 from enum import Enum
+from typing import Annotated
+import numpy as np
+from numpy.typing import NDArray
+
+Array5 = Annotated[NDArray[np.float64], '5']
+Array5x1 = Annotated[NDArray[np.float64], '5x1']
+Array5x8760 = Annotated[NDArray[np.float64], '5x8760']
+Array12 = Annotated[NDArray[np.float64], '12']
+Array12x1 = Annotated[NDArray[np.float64], '12x1']
+Array12x8760 = Annotated[NDArray[np.float64], '12x8760']
+Array8760 = Annotated[NDArray[np.float64], '8760']
+# これ以外のその他変則的な次元はその場で定義
 
 # NOTE: import * して利用するので、jjj_ 付けるとわかりやすい
 

--- a/src/jjjexperiment/inputs/ArgHEntity.py
+++ b/src/jjjexperiment/inputs/ArgHEntity.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Any
-from nptyping import Float64, NDArray, Shape
 
 import pyhees.section3_1_e as algo
 import pyhees.section4_2 as dc

--- a/src/jjjexperiment/inputs/climate_entity.py
+++ b/src/jjjexperiment/inputs/climate_entity.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Any
-from nptyping import Float64, NDArray, Shape
 
 import pyhees.section3_1_e as algo
 import pyhees.section4_2 as dc
@@ -16,22 +15,22 @@ class ClimateEntity:
         self.region = region
         self.climate = rgn.load_climate(region)
 
-    def get_J_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_J_d_t(self) -> Array8760:
         J_d_t = slr.calc_I_s_d_t(0, 0, rgn.get_climate_df(self.climate))
         return J_d_t
 
-    def get_X_ex_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_X_ex_d_t(self) -> Array8760:
         X_ex_d_t = rgn.get_X_ex(self.climate)
         return X_ex_d_t
 
-    def get_Theta_ex_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_Theta_ex_d_t(self) -> Array8760:
         Theta_ex_d_t = rgn.get_Theta_ex(self.climate)
         return Theta_ex_d_t
 
     def get_Theta_g_avg(self) -> float:
         return algo.get_Theta_g_avg(self.get_Theta_ex_d_t())
 
-    def get_HCM_d_t(self) -> NDArray[Shape['8760'], Any]:
+    def get_HCM_d_t(self) -> Array8760:
         H, C, M = dc.get_season_array_d_t(self.region)
         HCM = []
         for i in range(len(H)):

--- a/src/jjjexperiment/inputs/environment_entity.py
+++ b/src/jjjexperiment/inputs/environment_entity.py
@@ -1,5 +1,4 @@
 import numpy as np
-from nptyping import Float64, NDArray, Shape
 
 import pyhees.section3_1 as ld
 import pyhees.section3_2 as gihi
@@ -8,6 +7,7 @@ import pyhees.section4_2_b as dc_spec
 import pyhees.section11_1 as rgn
 import pyhees.section11_2 as slr
 # JJJ
+from jjjexperiment.common import *
 import jjjexperiment.inputs as jjj_ipt
 
 class EnvironmentEntity:
@@ -31,31 +31,31 @@ class EnvironmentEntity:
         mu_C = gihi.get_mu_C(self.__input.eta_A_C, self.r_env)
         return mu_C
 
-    def get_A_HCZ_i(self) -> NDArray[Shape['12'], Float64]:
+    def get_A_HCZ_i(self) -> Array12:
         return np.array([
             ld.get_A_HCZ_i(i, self.__input.A_A, self.__input.A_MR, self.__input.A_OR) \
             for i in range(1, 13)
         ])
 
-    def get_A_HCZ_R_i(self) -> NDArray[Shape['12'], Float64]:
+    def get_A_HCZ_R_i(self) -> Array12:
         return np.array([
             ld.get_A_HCZ_R_i(i) \
             for i in range(1, 13)
         ])
 
-    def get_V_vent_g_i(self) -> NDArray[Shape['5'], Float64]:
+    def get_V_vent_g_i(self) -> Array5:
         # (62) 全般換気量
         A_HCZ_i = [ld.get_A_HCZ_i(i, self.__input.A_A, self.__input.A_MR, self.__input.A_OR) for i in range(1, 6)]
         A_HCZ_R_i = [ld.get_A_HCZ_R_i(i) for i in range(1, 6)]
         V_vent_g_i = dc.get_V_vent_g_i(A_HCZ_i, A_HCZ_R_i)
         return np.array(V_vent_g_i)
 
-    def get_V_vent_l_NR_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_V_vent_l_NR_d_t(self) -> Array8760:
         # (63) 局所排気量
         V_vent_l_NR_d_t = dc.get_V_vent_l_NR_d_t()
         return V_vent_l_NR_d_t
 
-    def get_q_gen_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_q_gen_d_t(self) -> Array8760:
         A_NR = ld.get_A_NR(self.__input.A_A, self.__input.A_MR, self.__input.A_OR)
         # (64d) 非居室の内部発熱
         q_gen_NR_d_t = dc.calc_q_gen_NR_d_t(A_NR)
@@ -67,7 +67,7 @@ class EnvironmentEntity:
         q_gen_d_t = dc.get_q_gen_d_t(q_gen_NR_d_t, q_gen_OR_d_t, q_gen_MR_d_t)
         return q_gen_d_t
 
-    def get_n_p_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_n_p_d_t(self) -> Array8760:
         A_NR = ld.get_A_NR(self.__input.A_A, self.__input.A_MR, self.__input.A_OR)
         # (66d) 非居室の在室人数
         n_p_NR_d_t = dc.calc_n_p_NR_d_t(A_NR)
@@ -79,7 +79,7 @@ class EnvironmentEntity:
         n_p_d_t = dc.get_n_p_d_t(n_p_NR_d_t, n_p_OR_d_t, n_p_MR_d_t)
         return n_p_d_t
 
-    def get_w_gen_d_t(self) -> NDArray[Shape['8760'], Float64]:
+    def get_w_gen_d_t(self) -> Array8760:
         A_NR = ld.get_A_NR(self.__input.A_A, self.__input.A_MR, self.__input.A_OR)
         # (65d) 非居室の内部発湿
         w_gen_NR_d_t = dc.calc_w_gen_NR_d_t(A_NR)

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -996,7 +996,7 @@ def calc_Q_UT_A(case_name, A_A, A_MR, A_OR, r_env, mu_H, mu_C, q_hs_rtd_H, q_hs_
                     V_supply_i = V_supply_d_t_i[:, t:t+1],
                     Theta_supply_i = Theta_supply_d_t_i[:, t:t+1],
                     U_prt = U_prt,
-                    A_prt = A_prt_i.reshape(-1,1)[:5, :],
+                    A_prt_i = A_prt_i.reshape(-1,1)[:5, :],
                     Q = Q,
                     A_HCZ_i = A_HCZ_i.reshape(-1,1),
                     L_star_H_i = L_star_H_d_t_i[:, t:t+1],

--- a/src/jjjexperiment/section4_2_a.py
+++ b/src/jjjexperiment/section4_2_a.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pandas as pd
 from datetime import datetime
-from nptyping import NDArray, Shape, Float64
 
 import pyhees.section4_2_a as dc_a
 import pyhees.section4_3
 
 # JJJ
+from jjjexperiment.common import *
 from jjjexperiment.denchu_1 import Spec
 from jjjexperiment.logger import LimitedLoggerAdapter as _logger, log_res  # デバッグ用ロガー
 import jjjexperiment.constants as jjj_consts
@@ -23,7 +23,7 @@ def calc_E_E_fan_H_d_t(
         C_df_H_d_t,  # 暖房出力補正係数
         P_rac_fan_rtd_H, P_fan_rtd_H,  # 定格暖房時
         f_SFP_H  # その他
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (37)改 E_E_fan_H_d_t
     """
     # (3) 日付dの時刻tにおける1時間当たりの熱源機の平均暖房能力(W)
@@ -59,7 +59,7 @@ def calc_E_E_fan_C_d_t(
         X_hs_out_d_t, X_hs_in_d_t,  # 絶対湿度
         P_rac_fan_rtd_C, P_fan_rtd_C,  # 定格暖房時
         f_SFP_C  # その他
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (38)改 E_E_fan_C_d_t
     """
     # (4) 日付dの時刻tにおける1時間当たりの熱源機の平均冷房能力(-)
@@ -96,8 +96,8 @@ def calc_E_E_fan_C_d_t(
 @log_res(['E_E_H_d_t(type:1,3)'])
 def calc_E_E_H_d_t_type1_and_type3(
         type: str,
-        E_E_fan_H_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_H_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_H_d_t: Array8760,
+        q_hs_H_d_t: Array8760,
         Theta_hs_out_d_t, Theta_hs_in_d_t, Theta_ex_d_t,  # 空気温度
         V_hs_supply_d_t,  # 風量
         q_hs_rtd_C,  # 定格冷房能力※
@@ -105,7 +105,7 @@ def calc_E_E_H_d_t_type1_and_type3(
         q_hs_mid_H, P_hs_mid_H, V_fan_mid_H, P_fan_mid_H,  # 中間冷房時
         q_hs_rtd_H, P_fan_rtd_H, V_fan_rtd_H, P_hs_rtd_H,  # 定格冷房時
         EquipmentSpec,  # その他
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (1)改 E_E_H_d_t
     """
     assert type == PROCESS_TYPE_1 or type == PROCESS_TYPE_3, "type1,3 専用ロジック"
@@ -146,8 +146,8 @@ def calc_E_E_H_d_t_type2(
         type: str,
         region: int,
         climateFile,
-        E_E_fan_H_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_H_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_H_d_t: Array8760,
+        q_hs_H_d_t: Array8760,
         e_rtd_H: float,
         q_rtd_H: float,
         q_rtd_C: float,
@@ -155,7 +155,7 @@ def calc_E_E_H_d_t_type2(
         q_max_C: float,
         input_C_af_H: float,
         dualcompressor_H: bool,
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (1)改 E_E_H_d_t
     """
     assert type == PROCESS_TYPE_2, "type2 専用ロジック"
@@ -178,15 +178,15 @@ def calc_E_E_H_d_t_type4(
         type: str,
         region: int,
         climateFile,
-        E_E_fan_H_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_H_d_t: NDArray[Shape['8760'], Float64],
-        V_hs_supply_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_H_d_t: Array8760,
+        q_hs_H_d_t: Array8760,
+        V_hs_supply_d_t: Array8760,
         P_rac_fan_rtd_H: float,
         simu_R_H,
         spec: Spec,
         Theta_real_inner,
         RH_real_inner,
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (1)改 E_E_H_d_t
     """
     assert type == PROCESS_TYPE_4, "type4 専用ロジック"
@@ -230,7 +230,7 @@ def calc_E_E_H_d_t_type4(
 @log_res(['E_E_C_d_t(type:1,3)'])
 def calc_E_E_C_d_t_type1_and_type3(
         type, region,
-        E_E_fan_C_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_C_d_t: Array8760,
         Theta_hs_out_d_t, Theta_hs_in_d_t, Theta_ex_d_t,  # 空気温度
         V_hs_supply_d_t,  # 風量
         X_hs_out_d_t, X_hs_in_d_t,  # 絶対湿度
@@ -238,7 +238,7 @@ def calc_E_E_C_d_t_type1_and_type3(
         q_hs_mid_C, P_hs_mid_C, V_fan_mid_C, P_fan_mid_C,  # 中間冷房時
         q_hs_rtd_C, P_fan_rtd_C, V_fan_rtd_C, P_hs_rtd_C,  # 定格冷房時
         EquipmentSpec,  # その他
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (2)改 E_E_C_d_t
     """
     assert type == PROCESS_TYPE_1 or type == PROCESS_TYPE_3, "type1,3 専用ロジック"
@@ -285,15 +285,15 @@ def calc_E_E_C_d_t_type2(
         type: str,
         region: int,
         climateFile,
-        E_E_fan_C_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_CS_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_CL_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_C_d_t: Array8760,
+        q_hs_CS_d_t: Array8760,
+        q_hs_CL_d_t: Array8760,
         e_rtd_C: float,
         q_rtd_C: float,
         q_max_C: float,
         input_C_af_C: float,
         dualcompressor_C: bool,
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (2)改 E_E_C_d_t
     """
     assert type == PROCESS_TYPE_2, "type2 専用ロジック"
@@ -316,15 +316,15 @@ def calc_E_E_C_d_t_type4(
         type: str,
         region: int,
         climateFile,
-        E_E_fan_C_d_t: NDArray[Shape['8760'], Float64],
-        q_hs_C_d_t: NDArray[Shape['8760'], Float64],  # NOTE: CS/CL 足せばよい
-        V_hs_supply_d_t: NDArray[Shape['8760'], Float64],
+        E_E_fan_C_d_t: Array8760,
+        q_hs_C_d_t: Array8760,  # NOTE: CS/CL 足せばよい
+        V_hs_supply_d_t: Array8760,
         P_rac_fan_rtd_C: float,
         simu_R_C,
         spec: Spec,
         Theta_real_inner,
         RH_real_inner,
-    ) -> NDArray[Shape['8760'], Float64]:
+    ) -> Array8760:
     """ (2)改 E_E_C_d_t
     """
     assert type == PROCESS_TYPE_4, "type4 専用ロジック"

--- a/src/jjjexperiment/underfloor_ac/section4_2.py
+++ b/src/jjjexperiment/underfloor_ac/section4_2.py
@@ -1,4 +1,3 @@
-from nptyping import Float64, NDArray, Shape
 import numpy as np
 
 import pyhees.section3_1_e as algo
@@ -10,7 +9,7 @@ from jjjexperiment.common import *
 from jjjexperiment.options import *
 
 
-def get_r_A_uf_i() -> NDArray[Shape['12, 1'], Float64]:
+def get_r_A_uf_i() -> Array12x1:
     """暖冷房区画iの床面積のうち床下空間に接する床面積の割合 (-)
     """
     r_A_uf_i = np.array([
@@ -24,10 +23,10 @@ def get_A_s_ufac_i(
         A_A: float,
         A_MR: float,
         A_OR: float
-    ) -> tuple[NDArray[Shape["12, 1"], Float64], float]:
+    ) -> tuple[Array12x1, float]:
     """
     Returns:
-        tuple(NDArray[Shape["12, 1"], Float64], float):
+        tuple(Array12x1, float):
             - A_s_ufac_i: 暖冷房区画iの床下空調有効面積[m2]
             - r_A_s_ufac: 面積全体における床下空調部分の床面積の比率[-]
     """
@@ -87,9 +86,9 @@ def calc_Theta_uf(
 # vectorizeできなのいのでhstack-broadcastで対応 (A_s_ufac_iが強制でfloatになるため)
 def calc_delta_L_room2uf_i(
         U_s: float,
-        A_s_ufac_i: NDArray[Shape['5, 1'], Float64],
+        A_s_ufac_i: Array5x1,
         delta_Theta: float
-    ) -> NDArray[Shape['5, 1'], Float64]:
+    ) -> Array5x1:
     """床下空間から居室全体への熱損失 [MJ/h]
     """
     assert A_s_ufac_i.ndim == 2

--- a/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
+++ b/src/jjjexperiment/underfloor_ac/section4_2_f46_f48.py
@@ -1,4 +1,3 @@
-from nptyping import Float64, NDArray, Shape
 import numpy as np
 
 import pyhees.section4_2 as dc
@@ -12,18 +11,18 @@ from jjjexperiment.options import *
 @jjj_cloning
 def get_Theta_HBR_i(
         Theta_star_HBR: float,
-        V_supply_i: NDArray[Shape['5, 1'], Float64],
-        Theta_supply_i: NDArray[Shape['5, 1'], Float64],
+        V_supply_i: Array5x1,
+        Theta_supply_i: Array5x1,
         U_prt: float,
-        A_prt_i: NDArray[Shape['5, 1'], Float64],
+        A_prt_i: Array5x1,
         Q: float,
-        A_HCZ_i: NDArray[Shape['5, 1'], Float64],
-        L_star_H_i: NDArray[Shape['5, 1'], Float64],
-        L_star_CS_i: NDArray[Shape['5, 1'], Float64],
+        A_HCZ_i: Array5x1,
+        L_star_H_i: Array5x1,
+        L_star_CS_i: Array5x1,
         HCM: JJJ_HCM,
-        A_s_ufac_i: NDArray[Shape['5, 1'], Float64],
+        A_s_ufac_i: Array5x1,
         Theta_uf: float,
-    ) -> NDArray[Shape['5, 1'], Float64]:
+    ) -> Array5x1:
     """単時点版 (46-1)(46-2)(46-3) の床下空調 補正
     """
     # 事前条件:
@@ -79,13 +78,13 @@ def get_Theta_HBR_i(
 def get_Theta_NR(
         Theta_star_NR: float,
         Theta_star_HBR: float,
-        Theta_HBR_i: NDArray[Shape['5, 1'], Float64],
+        Theta_HBR_i: Array5x1,
         A_NR: float,
         V_vent_l_NR: float,
-        V_dash_supply_i: NDArray[Shape['5, 1'], Float64],
-        V_supply_i: NDArray[Shape['5, 1'], Float64],
+        V_dash_supply_i: Array5x1,
+        V_supply_i: Array5x1,
         U_prt: float,
-        A_prt_i: NDArray[Shape['5, 1'], Float64],
+        A_prt_i: Array5x1,
         Q: float,
         Theta_uf: float,
     ) -> float:


### PR DESCRIPTION
google colab のバージョンアップで numpy.2系がデフォルトとなっており、そちらに未対応のパッケージを除外した。
