### PR TITLE
過剰熱量繰越による負荷が二重で乗っている不具合を修正

### DIFF
--- a/src/jjjexperiment/carryover_heat/section4_2.py
+++ b/src/jjjexperiment/carryover_heat/section4_2.py
@@ -123,7 +123,7 @@ def get_L_star_CS_i_2024(
 # デメリットは、クライアントコードに知識が必要になる(時点の選択)
 
 def get_Theta_HBR_i_2023(
-        isFirst: bool, H: bool, C: bool, M: bool,
+        H: bool, C: bool, M: bool,
         Theta_star_HBR: float,
         V_supply_i: Array5x1,
         Theta_supply_i: Array5x1,
@@ -172,12 +172,6 @@ def get_Theta_HBR_i_2023(
     # 熱容量(居室) [J/K]
     cbri = jjj_carryover_heat.get_C_BR_i(A_HCZ_i)
 
-    # NOTE: 250625 梅本様より絶対値を外すよう指摘に対応しました
-    carryover_theta_diff = Theta_HBR_before_i - Theta_star_HBR
-
-    # 熱繰越による熱容量[J] (1/1/0:00 なしとする)
-    carryover_capacity = 0 if isFirst else cbri * carryover_theta_diff
-
     # 熱容量(空調空気) [J/(K・h)]
     c_ac_air = dc.get_c_p_air() * dc.get_rho_air() * V_supply_i
 
@@ -189,14 +183,14 @@ def get_Theta_HBR_i_2023(
     elif H:  # 暖房期 (46-1)
         load_capacity = L_star_H_i * 10**6  # [MJ/h] -> [J/h]
         Theta_HBR_i = Theta_star_HBR \
-                    + (ac_capacity + carryover_capacity - load_capacity) \
+                    + (ac_capacity - load_capacity) \
                     / (c_ac_air + c_prt + heat_loss + cbri)
         # NOTE: 負荷バランス時の居室の室温で下限を設定 -> しない
         # Theta_HBR_i = np.clip(Theta_HBR_i, Theta_star_HBR, None)
     elif C:  # 冷房期 (46-2)
         load_capacity = L_star_CS_i * 10**6  # [MJ/h] -> [J/h]
         Theta_HBR_i = Theta_star_HBR \
-                    -1 * (ac_capacity + carryover_capacity - load_capacity) \
+                    -1 * (ac_capacity - load_capacity) \
                     / (c_ac_air + c_prt + heat_loss + cbri)
         # NOTE: 負荷バランス時の居室の室温で下限を設定 -> しない
         # Theta_HBR_i = np.clip(Theta_HBR_i, None, Theta_star_HBR)

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -786,7 +786,7 @@ def calc_Q_UT_A(
             # (46)　暖冷房区画𝑖の実際の居室の室温
             Theta_HBR_d_t_i[:, t:t+1] \
                 = jjj_carryover_heat.get_Theta_HBR_i_2023(
-                    isFirst, H[t], C[t], M[t],
+                    H[t], C[t], M[t],
                     Theta_star_HBR_d_t[t],
                     V_supply_d_t_i[:, t:t+1],  # (5,1)
                     Theta_supply_d_t_i[:, t:t+1],  # (5,1)

--- a/src/tests/carryover_heat/test_4_2_formula_46_48.py
+++ b/src/tests/carryover_heat/test_4_2_formula_46_48.py
@@ -31,7 +31,7 @@ def test_過剰熱量繰越を考慮した室温_居室_式46():
     # Act
     Theta_HBR_i \
         = jjj_carryover_heat.get_Theta_HBR_i_2023(
-            isFirst = (2==0), H = True, C = False, M = False,
+            H = True, C = False, M = False,
             Theta_star_HBR = 20,
             V_supply_i = V_supply_i,
             Theta_supply_i = Theta_supply_i,

--- a/src/tests/carryover_heat/test_4_2_formula_46_48.py
+++ b/src/tests/carryover_heat/test_4_2_formula_46_48.py
@@ -47,7 +47,7 @@ def test_過剰熱量繰越を考慮した室温_居室_式46():
     assert Theta_HBR_i.shape == (5, 1), "Theta_HBR_iの次数が想定外"
 
     # NOTE: 資料ではキャップされていないが、実装ではキャップされている
-    exp_Theta_HBR_i = np.array([19.63, 21.29, 21.49, 19.97, 19.64]).reshape(-1,1)
+    exp_Theta_HBR_i = np.array([19.63, 20.87, 21.02, 19.97, 19.64]).reshape(-1,1)
 
     np.testing.assert_almost_equal(Theta_HBR_i, exp_Theta_HBR_i, decimal=2), "Theta_HBR_iの計算がおかしい"
     # assert つかないの間違えやすいので注意


### PR DESCRIPTION
過剰熱量繰越が二重で乗っている不具合（正確には仕様間違い）を修正しました。
式を変えたから当然なのですが、テストが1件通っていません。
どうやって答えを直せば良いのか分からないので教えてください（どこかで手計算している？）。