### PR TITLE
過剰熱量繰越時に未処理負荷が多く算出されてしまうため、L'を調整する

### DIFF
--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -1376,6 +1376,13 @@ def calc_Q_UT_A(
     )
     # (5)　間仕切りの熱損失を含む実際の暖房負荷
     L_dash_H_d_t_i = dc.get_L_dash_H_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region)
+
+    # 過剰熱量繰越をするときは、L_dashが負になる場合は0として扱う
+    if carryover_heat_dto.carry_over_heat == 過剰熱量繰越計算.行う:
+        L_dash_CL_d_t_i = np.clip(L_dash_CL_d_t_i, 0, None)
+        L_dash_CS_d_t_i = np.clip(L_dash_CS_d_t_i, 0, None)
+        L_dash_H_d_t_i = np.clip(L_dash_H_d_t_i, 0, None)
+
     df_output = df_output.assign(
         L_dash_H_d_t_1 = L_dash_H_d_t_i[0],
         L_dash_H_d_t_2 = L_dash_H_d_t_i[1],

--- a/src/jjjexperiment/section4_2.py
+++ b/src/jjjexperiment/section4_2.py
@@ -1357,7 +1357,12 @@ def calc_Q_UT_A(
 
     """ まとめ - 実際の暖冷房負荷 """
     # (7)　間仕切りの熱取得を含む実際の冷房潜熱負荷
-    L_dash_CL_d_t_i = dc.get_L_dash_CL_d_t_i(V_supply_d_t_i, X_HBR_d_t_i, X_supply_d_t_i, house.region)
+    if carryover_heat_dto.carry_over_heat == 過剰熱量繰越計算.行う:
+        L_dash_CL_d_t_i = np.clip(
+            dc.get_L_dash_CL_d_t_i(V_supply_d_t_i, X_HBR_d_t_i, X_supply_d_t_i, house.region), # 従来式
+            0, None)
+    else:
+        L_dash_CL_d_t_i = dc.get_L_dash_CL_d_t_i(V_supply_d_t_i, X_HBR_d_t_i, X_supply_d_t_i, house.region)
     df_output = df_output.assign(
         L_dash_CL_d_t_1 = L_dash_CL_d_t_i[0],
         L_dash_CL_d_t_2 = L_dash_CL_d_t_i[1],
@@ -1366,7 +1371,12 @@ def calc_Q_UT_A(
         L_dash_CL_d_t_5 = L_dash_CL_d_t_i[4]
     )
     # (6)　間仕切りの熱取得を含む実際の冷房顕熱負荷
-    L_dash_CS_d_t_i = dc.get_L_dash_CS_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region)
+    if carryover_heat_dto.carry_over_heat == 過剰熱量繰越計算.行う:
+        L_dash_CS_d_t_i = np.clip(
+            dc.get_L_dash_CS_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region), # 従来式
+            0, None)
+    else:
+        L_dash_CS_d_t_i = dc.get_L_dash_CS_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region)
     df_output = df_output.assign(
         L_dash_CS_d_t_1 = L_dash_CS_d_t_i[0],
         L_dash_CS_d_t_2 = L_dash_CS_d_t_i[1],
@@ -1375,14 +1385,12 @@ def calc_Q_UT_A(
         L_dash_CS_d_t_5 = L_dash_CS_d_t_i[4]
     )
     # (5)　間仕切りの熱損失を含む実際の暖房負荷
-    L_dash_H_d_t_i = dc.get_L_dash_H_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region)
-
-    # 過剰熱量繰越をするときは、L_dashが負になる場合は0として扱う
     if carryover_heat_dto.carry_over_heat == 過剰熱量繰越計算.行う:
-        L_dash_CL_d_t_i = np.clip(L_dash_CL_d_t_i, 0, None)
-        L_dash_CS_d_t_i = np.clip(L_dash_CS_d_t_i, 0, None)
-        L_dash_H_d_t_i = np.clip(L_dash_H_d_t_i, 0, None)
-
+        L_dash_H_d_t_i = np.clip(
+            dc.get_L_dash_H_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region), # 従来式
+            0, None)
+    else:
+        L_dash_H_d_t_i = dc.get_L_dash_H_d_t_i(V_supply_d_t_i, Theta_supply_d_t_i, Theta_HBR_d_t_i, house.region)
     df_output = df_output.assign(
         L_dash_H_d_t_1 = L_dash_H_d_t_i[0],
         L_dash_H_d_t_2 = L_dash_H_d_t_i[1],


### PR DESCRIPTION
過剰熱量繰越時に未処理負荷が多く算出されてしまうことへの対応として、L'を調整します。
居室ごとの L'_d,t,i ≦ 0 のとき、 L'_d,t,i = 0 となるようにします。

繰越がない場合にもこの処理をしてしまうと、計算結果が変わってしまいます。
繰越がある場合だけ、この処理をします。

コードの書き方が山名さん流になっていないです。（全部 section4_2.py だけに書きました）
リファクタリングをお願いしても良いでしょうか？