### PR TITLE
バージョン日時定数を自動アクションで更新する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "awsAuthRefresh": "aws sso login",
   "permissions": {
       "deny": [
       "Read(**/.env*)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "awsAuthRefresh": "aws sso login",
+  "permissions": {
+      "deny": [
+      "Read(**/.env*)"
+      ]
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,10 +7,10 @@
 	// NOTE: google colab にインポートして使用するのでバージョンを合わせる
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {
+	// 	"ghcr.io/devcontainers/features/aws-cli:1": {}
+	// },
   	// NOTE: bedrock 利用設定は必須ではありません
-	"features": {
-		"ghcr.io/devcontainers/features/aws-cli:1": {}
-	},
   	"mounts": [
   	  "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind"
   	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,13 @@
 	// NOTE: google colab にインポートして使用するのでバージョンを合わせる
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  	// NOTE: bedrock 利用設定は必須ではありません
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {}
+	},
+  	"mounts": [
+  	  "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind"
+  	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -23,6 +29,7 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"amazonwebservices.aws-toolkit-vscode",
 				"mhutchie.git-graph",
 				"shardulm94.trailing-spaces",
 				"mechatroner.rainbow-csv",

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   pytest:
+    # アクションのループを防止
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -11,6 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # バージョン情報を自動更新
+      - name: Update version
+        run: |
+          DATE=$(date +%Y%m%d)
+          sed -i "s/return '_[0-9]*'/return '_$DATE'/" src/jjjexperiment/constants.py
+
       # NOTE: Poetry仮想環境を使用している時であってもバージョン指定する場合には必要
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -49,3 +55,13 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           junit_files: artifacts/**/*.xml
+
+      # バージョン更新をコミットしてプッシュ
+      - name: Commit and push version update
+        if: success()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/jjjexperiment/constants.py
+          git commit -m "chore: auto-update version" || echo "No changes to commit"
+          git push

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -16,7 +16,7 @@ jobs:
       # バージョン情報を自動更新
       - name: Update version
         run: |
-          DATE=$(date +%Y%m%d)
+          DATE=$(TZ='Asia/Tokyo' date +%Y%m%d)
           sed -i "s/return '_[0-9]*'/return '_$DATE'/" src/jjjexperiment/constants.py
 
       # NOTE: Poetry仮想環境を使用している時であってもバージョン指定する場合には必要

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          junit_files: artifacts/**/*.xml
+          files: artifacts/**/*.xml
 
       # バージョン更新をコミットしてプッシュ
       - name: Commit and push version update

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 
 # Poetry
 # NOTE: poetry.lock は除外しない(依存バージョンを固定しており開発者間で共有すべきものです)
+
+# Claude private settings
+.claude/settings.local.json

--- a/src/jjjexperiment/constants.py
+++ b/src/jjjexperiment/constants.py
@@ -5,7 +5,7 @@ def version_info() -> str:
   """
   # NOTE: subprocessモジュールによるコミット履歴からの生成は \
   # ipynb 環境では正常に動作しないことを確認しました(returned no-zero exit status 128.)
-  return '_20250325'
+  return '_20260210'
 
 Theta_hs_out_max_H_d_t_limit: float = 45
 """最大暖房出力時の熱源機の出口における空気温度の最大値の上限値"""

--- a/src/jjjexperiment/constants.py
+++ b/src/jjjexperiment/constants.py
@@ -1,7 +1,7 @@
 from jjjexperiment.inputs.options import *
 
 def version_info() -> str:
-  """ 最終編集日をバージョン管理に使用します
+  """ 最終編集日(プッシュ日)をバージョン管理に使用します
   """
   # NOTE: GitHub Actions 経由でプッシュされた日で上書きしています
   # 本ファイル名に変更があれば 設定更新すること

--- a/src/jjjexperiment/constants.py
+++ b/src/jjjexperiment/constants.py
@@ -3,8 +3,8 @@ from jjjexperiment.inputs.options import *
 def version_info() -> str:
   """ 最終編集日をバージョン管理に使用します
   """
-  # NOTE: subprocessモジュールによるコミット履歴からの生成は \
-  # ipynb 環境では正常に動作しないことを確認しました(returned no-zero exit status 128.)
+  # NOTE: GitHub Actions 経由でプッシュされた日で上書きしています
+  # 本ファイル名に変更があれば 設定更新すること
   return '_20260210'
 
 Theta_hs_out_max_H_d_t_limit: float = 45

--- a/src/tests/test_integration_execution.py
+++ b/src/tests/test_integration_execution.py
@@ -25,12 +25,12 @@ class Test統合テスト_デフォルト入力時:
         """
         result = calc(self._inputs2, test_mode=True)
 
-        assert result['TInput'].q_rtd_C == expected_inputs.q_rtd_C
-        assert result['TInput'].q_rtd_H == expected_inputs.q_rtd_H
-        assert result['TInput'].q_max_C == expected_inputs.q_max_C
-        assert result['TInput'].q_max_H == expected_inputs.q_max_H
-        assert result['TInput'].e_rtd_C == expected_inputs.e_rtd_C
-        assert result['TInput'].e_rtd_H == expected_inputs.e_rtd_H
+        assert result['TInput'].q_rtd_C == pytest.approx(expected_inputs.q_rtd_C)
+        assert result['TInput'].q_rtd_H == pytest.approx(expected_inputs.q_rtd_H)
+        assert result['TInput'].q_max_C == pytest.approx(expected_inputs.q_max_C)
+        assert result['TInput'].q_max_H == pytest.approx(expected_inputs.q_max_H)
+        assert result['TInput'].e_rtd_C == pytest.approx(expected_inputs.e_rtd_C)
+        assert result['TInput'].e_rtd_H == pytest.approx(expected_inputs.e_rtd_H)
 
     def test_関数_deep_update(self):
         """ 階層のあるインプットを使用してインプットを拡張するテスト
@@ -74,8 +74,8 @@ class Test統合テスト_デフォルト入力時:
         # inputs = change_testmode_input_V_hs_min_C(inputs)
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H == expected_result_type2.E_H
-        assert result['TValue'].E_C == expected_result_type2.E_C
+        assert result['TValue'].E_H == pytest.approx(expected_result_type2.E_H, rel=1e-6)
+        assert result['TValue'].E_C == pytest.approx(expected_result_type2.E_C, rel=1e-6)
 
     def test_計算結果一致_方式3(self, expected_result_type1, expected_result_type2):
         """ 方式3 最後まで実行できること、結果がちゃんと変わることだけ確認
@@ -87,11 +87,11 @@ class Test統合テスト_デフォルト入力時:
         # inputs = change_testmode_input_V_hs_min_C(inputs)
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C != expected_result_type1.E_C
+        assert result['TValue'].E_H != pytest.approx(expected_result_type1.E_H, rel=1e-6)
+        assert result['TValue'].E_C != pytest.approx(expected_result_type1.E_C, rel=1e-6)
 
-        assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_C != expected_result_type2.E_C
+        assert result['TValue'].E_H != pytest.approx(expected_result_type2.E_H, rel=1e-6)
+        assert result['TValue'].E_C != pytest.approx(expected_result_type2.E_C, rel=1e-6)
 
     def test_計算結果一致_方式4(self, expected_result_type1, expected_result_type2):
         """ 方式4 最後まで実行できること、結果がちゃんと変わることだけ確認
@@ -102,11 +102,11 @@ class Test統合テスト_デフォルト入力時:
         # inputs = change_testmode_input_V_hs_min_C(inputs)
         result = calc(inputs, test_mode=True)
 
-        assert result['TValue'].E_H != expected_result_type1.E_H
-        assert result['TValue'].E_C != expected_result_type1.E_C
+        assert result['TValue'].E_H != pytest.approx(expected_result_type1.E_H, rel=1e-6)
+        assert result['TValue'].E_C != pytest.approx(expected_result_type1.E_C, rel=1e-6)
 
-        assert result['TValue'].E_H != expected_result_type2.E_H
-        assert result['TValue'].E_C != expected_result_type2.E_C
+        assert result['TValue'].E_H != pytest.approx(expected_result_type2.E_H, rel=1e-6)
+        assert result['TValue'].E_C != pytest.approx(expected_result_type2.E_C, rel=1e-6)
 
 def change_testmode_VAV(inputs: dict):
     fixtures = {


### PR DESCRIPTION
# 概要

出力ファイル名に更新バージョンの日を付けていたが、
手動更新だったためうまく運用されていなかった。
GitHub アクションでこの定数更新を自動化した。

自動作成されるコミットの例
<img width="932" height="334" alt="image" src="https://github.com/user-attachments/assets/6b6b4a53-c257-41a3-9a7c-c672f9659ec1" />

# その他

- Claude Code 設定を追加（一応、個人ファイルのエスケープもいれたが、他開発者とバッティングするなら要調整）
