### PR TITLE
CICD実行制約を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,10 @@
 	// NOTE: google colab にインポートして使用するのでバージョンを合わせる
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {
-	// 	"ghcr.io/devcontainers/features/aws-cli:1": {}
-	// },
+	"features": {
+		// NOTE: Bedrock 利用者限定だが 必須のため追加させてもらう
+		"ghcr.io/devcontainers/features/aws-cli:1": {}
+	},
 
 	// NOTE: マウント失敗時にコンテナビルドエラーとなるためオプショナルなファイルには使用できない
   	"mounts": [
@@ -36,8 +37,7 @@
 				"mechatroner.rainbow-csv",
 				"takumii.markdowntable",
 				"shd101wyy.markdown-preview-enhanced",
-				// NOTE: 必要な人が各自でインストールする
-				// "amazonwebservices.aws-toolkit-vscode",
+				// NOTE: 以降は必要な人が各自でインストールする
 				// "anthropic.claude-code"
 			]
 		}

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -4,8 +4,11 @@ on: [push]
 
 jobs:
   pytest:
-    # アクションのループを防止
-    if: github.actor != 'github-actions[bot]'
+    # アクションのループを防止、作動させないブランチのルール
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.ref, 'refs/heads/jjj-experiment-') &&
+      github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/src/jjjexperiment/constants.py
+++ b/src/jjjexperiment/constants.py
@@ -5,7 +5,7 @@ def version_info() -> str:
   """
   # NOTE: GitHub Actions 経由でプッシュされた日で上書きしています
   # 本ファイル名に変更があれば 設定更新すること
-  return '_20260213'
+  return '_20260216'
 
 Theta_hs_out_max_H_d_t_limit: float = 45
 """最大暖房出力時の熱源機の出口における空気温度の最大値の上限値"""


### PR DESCRIPTION
# 概要

リリースブランチのCICDが走ってupstreamより進んでしまう問題を回避するため